### PR TITLE
support for hybrid policy compliance status

### DIFF
--- a/bundle/status/base_compliance_status_bundle.go
+++ b/bundle/status/base_compliance_status_bundle.go
@@ -1,17 +1,34 @@
 package status
 
-// PolicyComplianceStatus struct holds information for policy compliance status.
-type PolicyComplianceStatus struct {
+// PolicyCompleteComplianceStatus struct holds information for (optimized) policy compliance status.
+type PolicyCompleteComplianceStatus struct {
 	PolicyID                  string   `json:"policyId"`
 	NonCompliantClusters      []string `json:"nonCompliantClusters"`
 	UnknownComplianceClusters []string `json:"unknownComplianceClusters"`
 	ResourceVersion           string   `json:"resourceVersion"`
 }
 
-// BaseComplianceStatusBundle is the base struct for compliance status bundle.
-type BaseComplianceStatusBundle struct {
-	Objects              []*PolicyComplianceStatus `json:"objects"`
-	LeafHubName          string                    `json:"leafHubName"`
-	BaseBundleGeneration uint64                    `json:"baseBundleGeneration"`
-	Generation           uint64                    `json:"generation"`
+// PolicyDeltaComplianceStatus struct holds information for raw policy compliance status.
+type PolicyDeltaComplianceStatus struct {
+	PolicyID                  string   `json:"policyId"`
+	CompliantClusters         []string `json:"compliantClusters"`
+	NonCompliantClusters      []string `json:"nonCompliantClusters"`
+	UnknownComplianceClusters []string `json:"unknownComplianceClusters"`
+	ResourceVersion           string   `json:"resourceVersion"`
+}
+
+// BaseCompleteComplianceStatusBundle is the base struct for complete-compliance status bundle.
+type BaseCompleteComplianceStatusBundle struct {
+	Objects              []*PolicyCompleteComplianceStatus `json:"objects"`
+	LeafHubName          string                            `json:"leafHubName"`
+	BaseBundleGeneration uint64                            `json:"baseBundleGeneration"`
+	Generation           uint64                            `json:"generation"`
+}
+
+// BaseDeltaComplianceStatusBundle is the base struct for delta-compliance status bundle.
+type BaseDeltaComplianceStatusBundle struct {
+	Objects              []*PolicyDeltaComplianceStatus `json:"objects"`
+	LeafHubName          string                         `json:"leafHubName"`
+	BaseBundleGeneration uint64                         `json:"baseBundleGeneration"`
+	Generation           uint64                         `json:"generation"`
 }

--- a/bundle/status/base_compliance_status_bundle.go
+++ b/bundle/status/base_compliance_status_bundle.go
@@ -17,7 +17,7 @@ type PolicyDeltaComplianceStatus struct {
 	ResourceVersion           string   `json:"resourceVersion"`
 }
 
-// BaseCompleteComplianceStatusBundle is the base struct for complete-compliance status bundle.
+// BaseCompleteComplianceStatusBundle is the base struct for complete state compliance status bundle.
 type BaseCompleteComplianceStatusBundle struct {
 	Objects              []*PolicyCompleteComplianceStatus `json:"objects"`
 	LeafHubName          string                            `json:"leafHubName"`
@@ -25,7 +25,7 @@ type BaseCompleteComplianceStatusBundle struct {
 	Generation           uint64                            `json:"generation"`
 }
 
-// BaseDeltaComplianceStatusBundle is the base struct for delta-compliance status bundle.
+// BaseDeltaComplianceStatusBundle is the base struct for delta state compliance status bundle.
 type BaseDeltaComplianceStatusBundle struct {
 	Objects              []*PolicyDeltaComplianceStatus `json:"objects"`
 	LeafHubName          string                         `json:"leafHubName"`

--- a/msg_types.go
+++ b/msg_types.go
@@ -12,9 +12,9 @@ const (
 	ManagedClustersMsgKey = "ManagedClusters"
 	// ClustersPerPolicyMsgKey - clusters per policy message key.
 	ClustersPerPolicyMsgKey = "ClustersPerPolicy"
-	// PolicyCompleteComplianceMsgKey - policy complete-state compliance message key.
+	// PolicyCompleteComplianceMsgKey - policy complete state compliance message key.
 	PolicyCompleteComplianceMsgKey = "PolicyCompleteCompliance"
-	// PolicyDeltaComplianceMsgKey - policy delta-state compliance message key.
+	// PolicyDeltaComplianceMsgKey - policy delta state compliance message key.
 	PolicyDeltaComplianceMsgKey = "PolicyDeltaCompliance"
 	// MinimalPolicyComplianceMsgKey - minimal policy compliance message key.
 	MinimalPolicyComplianceMsgKey = "MinimalPolicyCompliance"

--- a/msg_types.go
+++ b/msg_types.go
@@ -12,8 +12,10 @@ const (
 	ManagedClustersMsgKey = "ManagedClusters"
 	// ClustersPerPolicyMsgKey - clusters per policy message key.
 	ClustersPerPolicyMsgKey = "ClustersPerPolicy"
-	// PolicyComplianceMsgKey - policy compliance message key.
-	PolicyComplianceMsgKey = "PolicyCompliance"
+	// PolicyCompleteComplianceMsgKey - policy complete-state compliance message key.
+	PolicyCompleteComplianceMsgKey = "PolicyCompleteCompliance"
+	// PolicyDeltaComplianceMsgKey - policy delta-state compliance message key.
+	PolicyDeltaComplianceMsgKey = "PolicyDeltaCompliance"
 	// MinimalPolicyComplianceMsgKey - minimal policy compliance message key.
 	MinimalPolicyComplianceMsgKey = "MinimalPolicyCompliance"
 )


### PR DESCRIPTION
- msg_types.go - split policy compliance msg key into two (one per mode).
- /bundle/status/base_compliance_status_bundle.go - was reworked to support both types of bundles.