### PR TITLE
Bundle Version Update

### DIFF
--- a/bundle/status/base_compliance_status_bundle.go
+++ b/bundle/status/base_compliance_status_bundle.go
@@ -9,13 +9,6 @@ type PolicyGenericComplianceStatus struct {
 	UnknownComplianceClusters []string `json:"unknownComplianceClusters"`
 }
 
-// BaseClustersPerPolicyBundle is the base struct for clusters per policy bundle and contains the full state.
-type BaseClustersPerPolicyBundle struct {
-	Objects     []*PolicyGenericComplianceStatus `json:"objects"`
-	LeafHubName string                           `json:"leafHubName"`
-	Generation  uint64                           `json:"generation"`
-}
-
 // PolicyCompleteComplianceStatus struct holds information for (optimized) policy compliance status.
 type PolicyCompleteComplianceStatus struct {
 	PolicyID                  string   `json:"policyId"`
@@ -23,12 +16,19 @@ type PolicyCompleteComplianceStatus struct {
 	UnknownComplianceClusters []string `json:"unknownComplianceClusters"`
 }
 
+// BaseClustersPerPolicyBundle is the base struct for clusters per policy bundle and contains the full state.
+type BaseClustersPerPolicyBundle struct {
+	Objects     []*PolicyGenericComplianceStatus `json:"objects"`
+	LeafHubName string                           `json:"leafHubName"`
+	BundleVersion
+}
+
 // BaseCompleteComplianceStatusBundle is the base struct for complete state compliance status bundle.
 type BaseCompleteComplianceStatusBundle struct {
 	Objects              []*PolicyCompleteComplianceStatus `json:"objects"`
 	LeafHubName          string                            `json:"leafHubName"`
 	BaseBundleGeneration uint64                            `json:"baseBundleGeneration"`
-	Generation           uint64                            `json:"generation"`
+	BundleVersion
 }
 
 // BaseDeltaComplianceStatusBundle is the base struct for delta state compliance status bundle.
@@ -36,5 +36,5 @@ type BaseDeltaComplianceStatusBundle struct {
 	Objects              []*PolicyGenericComplianceStatus `json:"objects"`
 	LeafHubName          string                           `json:"leafHubName"`
 	BaseBundleGeneration uint64                           `json:"baseBundleGeneration"`
-	Generation           uint64                           `json:"generation"`
+	BundleVersion
 }

--- a/bundle/status/base_compliance_status_bundle.go
+++ b/bundle/status/base_compliance_status_bundle.go
@@ -18,9 +18,9 @@ type PolicyCompleteComplianceStatus struct {
 
 // BaseClustersPerPolicyBundle is the base struct for clusters per policy bundle and contains the full state.
 type BaseClustersPerPolicyBundle struct {
-	Objects     []*PolicyGenericComplianceStatus `json:"objects"`
-	LeafHubName string                           `json:"leafHubName"`
-	BundleVersion
+	Objects       []*PolicyGenericComplianceStatus `json:"objects"`
+	LeafHubName   string                           `json:"leafHubName"`
+	BundleVersion BundleVersion                    `json:"bundleVersion"`
 }
 
 // BaseCompleteComplianceStatusBundle is the base struct for complete state compliance status bundle.
@@ -28,7 +28,7 @@ type BaseCompleteComplianceStatusBundle struct {
 	Objects              []*PolicyCompleteComplianceStatus `json:"objects"`
 	LeafHubName          string                            `json:"leafHubName"`
 	BaseBundleGeneration uint64                            `json:"baseBundleGeneration"`
-	BundleVersion
+	BundleVersion        BundleVersion                     `json:"bundleVersion"`
 }
 
 // BaseDeltaComplianceStatusBundle is the base struct for delta state compliance status bundle.
@@ -36,5 +36,5 @@ type BaseDeltaComplianceStatusBundle struct {
 	Objects              []*PolicyGenericComplianceStatus `json:"objects"`
 	LeafHubName          string                           `json:"leafHubName"`
 	BaseBundleGeneration uint64                           `json:"baseBundleGeneration"`
-	BundleVersion
+	BundleVersion        BundleVersion                    `json:"bundleVersion"`
 }

--- a/bundle/status/bundle_version.go
+++ b/bundle/status/bundle_version.go
@@ -1,7 +1,7 @@
 package status
 
 // NewBundleVersion returns a new instance of BundleVersion.
-func NewBundleVersion(incarnation, generation uint64) *BundleVersion {
+func NewBundleVersion(incarnation uint64, generation uint64) *BundleVersion {
 	return &BundleVersion{
 		Incarnation: incarnation,
 		Generation:  generation,

--- a/bundle/status/bundle_version.go
+++ b/bundle/status/bundle_version.go
@@ -1,0 +1,37 @@
+package status
+
+// NewBundleVersion returns a new instance of BundleVersion.
+func NewBundleVersion(incarnation, generation uint64) *BundleVersion {
+	return &BundleVersion{
+		Incarnation: incarnation,
+		Generation:  generation,
+	}
+}
+
+// BundleVersion holds the information necessary for the consumers of status bundles to compare versions correctly.
+// Incarnation is the instance-version of the sender component, a counter that increments on restarts of the latter.
+// Generation is the bundle-version relative to the sender's instance, increments on bundle updates.
+type BundleVersion struct {
+	Incarnation uint64 `json:"incarnation"`
+	Generation  uint64 `json:"generation"`
+}
+
+// NewerThan returns whether the caller's version is newer than that received as argument.
+//
+// If other = nil the result is true.
+func (bv *BundleVersion) NewerThan(other *BundleVersion) bool {
+	if other == nil {
+		return true
+	}
+
+	if bv.Incarnation == other.Incarnation {
+		return bv.Generation > other.Generation
+	}
+
+	return bv.Incarnation > other.Incarnation
+}
+
+// Equals returns whether the caller's version is equal to that received as argument.
+func (bv *BundleVersion) Equals(other *BundleVersion) bool {
+	return bv.Incarnation == other.Incarnation && bv.Generation == other.Generation
+}


### PR DESCRIPTION
- Added BundleVersion: a structure that wraps the Generation field and adds an Incarnation field, where the Incarnation is a "sender life-version counter" and the generation is a "bundle life-version counter" within the sender's instance.

- Replaced occurrences of Generation in status bundles with BundleVersion. BaseBundleGeneration remained as it was since it is a concept that exists within each sender-component instance.